### PR TITLE
fix Gemini streaming audio output choppiness

### DIFF
--- a/firebase_ai_logic_showcase/lib/demos/live_api/firebaseai_live_api_service.dart
+++ b/firebase_ai_logic_showcase/lib/demos/live_api/firebaseai_live_api_service.dart
@@ -59,7 +59,11 @@ class LiveApiService {
       responseModalities: [ResponseModalities.audio],
     ),
     tools: [
-      Tool.functionDeclarations([generateImageTool, setAppColorTool]),
+      Tool.functionDeclarations([
+        setAppColorTool,
+        // Gemini Flash Image currently requires the pay-as-you-go Blaze plan.
+        generateImageTool,
+      ]),
     ],
   );
 
@@ -156,6 +160,8 @@ class LiveApiService {
 
   Future<void> _handleTurnComplete() async {
     log('Model is done generating. Turn complete!');
+    final halfSecondOfSilence = Uint8List(24000);
+    _audioOutput.addDataToAudioStream(halfSecondOfSilence);
   }
 
   Future<void> _handleLiveServerToolCall(LiveServerToolCall response) async {

--- a/firebase_ai_logic_showcase/lib/demos/live_api/utilities/audio_output.dart
+++ b/firebase_ai_logic_showcase/lib/demos/live_api/utilities/audio_output.dart
@@ -50,8 +50,6 @@ class AudioOutput {
     }
 
     stream = SoLoud.instance.setBufferStream(
-      maxBufferSizeBytes:
-          1024 * 1024 * 10, // 10MB of max buffer (not allocated)
       bufferingType: BufferingType.released,
       bufferingTimeNeeds: 0,
       sampleRate: sampleRate,

--- a/firebase_ai_logic_showcase/pubspec.yaml
+++ b/firebase_ai_logic_showcase/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   flutter_image_compress: ^2.4.0
   waveform_flutter: ^1.2.0
   flutter_animate: ^4.5.2
-  firebase_ai: ^3.1.0
+  firebase_ai: ^3.3.0
   image_picker: ^1.1.2
   permission_handler: ^12.0.1
   flutter_markdown: ^0.7.7+1


### PR DESCRIPTION
Fix Gemini streaming audio output choppiness by adding half second of silence on turn complete in Live API demo. If there's not enough data in the audio output buffer, it will wait for more data before playing the audio. 

Half a second of silence would be a sequence of 24k bytes, all with a value of zero.

   * Sample Rate: 24,000 samples per second
   * Bit Depth: 16 bits, which is 2 bytes per sample
   * Channels: 1 (mono)

The total number of bytes for half second is 12k * 2 * 1 = 24k. In PCM audio, silence = sample value of 0. So we use a Uint8List of length 24,000, filled with zeros.

# Issue

When it's responding, it always stops before the last word or phrase of its response (usually about the same length of missing content).  And then, when it starts to respond to my next question, it "completes" its previous unfinished response by saying that missing last word or phrase.  And then continues on to respond to whatever I just asked about (and again, stopping before the last word or phrase... and on and on the same way throughout the conversation)

Rachel: Hi, what can you do for me?

Bot: Hi there! I'm a friendly assistant. For example, I can generate an image or change the color of

Rachel: Oh cool! You can generate images?  Like in a certain style?

Bot: this app. Yes! If you give me enough detail, I can generate an image in a cer

Rachel: Ok. Can you generate an image of a bear riding a bicycle along a city street in London.  Cartoon style.

Bot: tain style. Sure!  I'll generate an image of a bear... in car

Rachel: Thanks!

Bot: toon style. Is there anything else I can help you